### PR TITLE
Windows のみ ILMerge をするように対応

### DIFF
--- a/MasterConverterGUI.csproj
+++ b/MasterConverterGUI.csproj
@@ -114,7 +114,7 @@
     <Content Include="icon48x48.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
+  <PropertyGroup Condition="Exists('C:\Program Files (x86)')">
     <PostBuildEvent>set fname_new=$(TargetName)_merge$(TargetExt)
 if $(ConfigurationName) == Release (
   "C:\Program Files (x86)\Microsoft\ILMerge\ILMerge" /wildcards /ndebug /out:%25fname_new%25 $(TargetFileName) *.dll /targetplatform:v4,"C:\Windows\Microsoft.NET\Framework\v4.0.30319"


### PR DESCRIPTION
# 目的

mac, linux でビルドできるように対応

# やったこと

- PostBuildEvent の入っている PropertyGroup が windows でのみ有効になるようにした。

https://github.com/oTAMAKOo/MasterConverter/pull/1

こちらと同じ対応です。

# 確認したこと

- mac, linux(cent os) でビルドできること

